### PR TITLE
added email to become the unique identifier of accounts

### DIFF
--- a/src/server/lib/player/auth.js
+++ b/src/server/lib/player/auth.js
@@ -41,9 +41,8 @@ module.exports = function auth(email, password, nick) {
                     return resolve();
                 }
 
-                if (data.email && data.email !== email)
-                {
-                    console.log("auth: incorrect email");
+                if (data.email && data.email !== email) {
+                    debug("auth: incorrect email");
                     return reject();
                 }
 

--- a/src/server/routes/auth.js
+++ b/src/server/routes/auth.js
@@ -28,14 +28,11 @@ exports.required = function(req, res, next) {
         res.end();
     };
 
-    if (!credentials.name || !credentials.pass)
-    {
-        console.log(credentials);
-        console.log("No Email or Password in Auth Request");
+    if (!credentials.name || !credentials.pass) {
         return _error();
     } 
 
-    /* name = email */
+    /* credentials.name = email */
     player.auth(credentials.name, credentials.pass, nick).then(_success, _error);
 };
 

--- a/src/server/routes/auth.js
+++ b/src/server/routes/auth.js
@@ -28,8 +28,15 @@ exports.required = function(req, res, next) {
         res.end();
     };
 
-    if (!credentials.name || !credentials.pass) return _error();
-    player.auth(nick, credentials.name, credentials.pass).then(_success, _error);
+    if (!credentials.name || !credentials.pass)
+    {
+        console.log(credentials);
+        console.log("No Email or Password in Auth Request");
+        return _error();
+    } 
+
+    /* name = email */
+    player.auth(credentials.name, credentials.pass, nick).then(_success, _error);
 };
 
 exports.hof = function(req, res, next) {


### PR DESCRIPTION
In relation to https://github.com/sean3z/cncnet-api/issues/17

This changes the process of creating an account slightly. 

1. Ping the auth endpoint with a nickname you want to create as per normal. 
2. Instead of adding "username" in the username field, you add an "email"
3. The email becomes the main way of finding a users account.